### PR TITLE
metadata.desktop translation

### DIFF
--- a/package/metadata.desktop
+++ b/package/metadata.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Command Output
-Comment=Run a command periodically and render it's output.
+Comment=Run a command periodically and render its output.
 
 Type=Service
 Icon=utilities-terminal

--- a/package/translate/fr.po
+++ b/package/translate/fr.po
@@ -19,11 +19,11 @@ msgstr ""
 
 #: ../metadata.desktop
 msgid "Command Output"
-msgstr ""
+msgstr "Command Output"
 
 #: ../metadata.desktop
-msgid "Run a command periodically and render it's output."
-msgstr ""
+msgid "Run a command periodically and render its output."
+msgstr "Exécute une commande périodiquement et affiche son retour."
 
 #: ../contents/config/config.qml
 msgid "General"

--- a/package/translate/nl.po
+++ b/package/translate/nl.po
@@ -23,7 +23,7 @@ msgid "Command Output"
 msgstr ""
 
 #: ../metadata.desktop
-msgid "Run a command periodically and render it's output."
+msgid "Run a command periodically and render its output."
 msgstr ""
 
 #: ../contents/config/config.qml

--- a/package/translate/template.pot
+++ b/package/translate/template.pot
@@ -22,7 +22,7 @@ msgid "Command Output"
 msgstr ""
 
 #: ../metadata.desktop
-msgid "Run a command periodically and render it's output."
+msgid "Run a command periodically and render its output."
 msgstr ""
 
 #: ../contents/config/config.qml


### PR DESCRIPTION
I modified the English text too, that's "its" for possessive, not "it's". "it's" is for "it is". See https://en.wiktionary.org/wiki/its