### PR TITLE
Add tooltip string

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -10,6 +10,9 @@
 			<default>echo "Test $(date +%S)"</default>
 			<!-- <default>echo "&lt;a href=\"https://google.com\"&gt;Test $(date +%S)&lt;/a&gt;"</default> -->
 		</entry>
+		<entry name="toolTip" type="string">
+			<default></default>
+		</entry>
 		<entry name="waitForCompletion" type="bool">
 			<default>false</default>
 		</entry>

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -12,6 +12,7 @@ ConfigPage {
 	showAppletVersion: true
 	
 	property alias cfg_command: command.text
+	property alias cfg_toolTip: toolTip.text
 	property alias cfg_waitForCompletion: waitForCompletion.checked
 	property alias cfg_interval: interval.value
 	property alias cfg_clickCommand: clickCommand.text
@@ -24,6 +25,16 @@ ConfigPage {
 		TextField {
 			id: command
 			Layout.fillWidth: true
+		}
+
+		RowLayout {
+			Label {
+				text: i18n("Tooltip:")
+			}
+			TextField {
+				id: toolTip
+				Layout.fillWidth: true
+			}
 		}
 
 		RowLayout {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -55,6 +55,7 @@ Item {
 		readonly property color textColor: plasmoid.configuration.textColor || theme.textColor
 		readonly property color outlineColor: plasmoid.configuration.outlineColor || theme.backgroundColor
 		readonly property bool showOutline: plasmoid.configuration.showOutline
+		readonly property string toolTip: plasmoid.configuration.toolTip || ''
 
 		onCommandChanged: widget.runCommand()
 		onIntervalChanged: {
@@ -190,16 +191,17 @@ Item {
 			}
 		}
 
-		PlasmaCore.ToolTipArea {
-			anchors.fill: parent
-			subText: output.text
-			enabled: output.truncated
-		}
-
 		Text {
 			id: output
 			width: parent.width
 			height: parent.height
+
+			PlasmaCore.ToolTipArea {
+				anchors.fill: parent
+				mainText: config.toolTip
+				//subText: output.text
+				enabled: config.toolTip
+			}
 
 			text: widget.outputText
 


### PR DESCRIPTION
Hi, I made a simple patch to set a tooltip for the applet. I think it can be useful if you have several Command Output instances in the panel.

Thanks again for your useful applet.

Michele

![immagine](https://user-images.githubusercontent.com/12049118/153263481-742095fc-e512-4670-b1c1-f11e8c191eaa.png)
