### PR TITLE
Fix widget default size

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -7,6 +7,9 @@ import org.kde.plasma.components 2.0 as PlasmaComponent
 Item {
 	id: widget
 
+	width: PlasmaCore.Units.gridUnit * 15
+    height: PlasmaCore.Units.gridUnit * 25
+
 	// https://github.com/KDE/plasma-workspace/blob/master/dataengines/executable/executable.h
 	// https://github.com/KDE/plasma-workspace/blob/master/dataengines/executable/executable.cpp
 	// https://github.com/KDE/plasma-framework/blob/master/src/declarativeimports/core/datasource.h


### PR DESCRIPTION
I tried to fix the widget position that always moves to the left after a restart, turnout you need to define the default width and height. 