### PR TITLE
Allow customization of terminal colors

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -50,6 +50,54 @@
 		<entry name="textColor" type="string">
 			<default></default>
 		</entry>
+		<entry name="textc1base" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc1bright" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc2base" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc2bright" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc3base" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc3bright" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc4base" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc4bright" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc5base" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc5bright" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc6base" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc6bright" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc7base" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc7bright" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc8base" type="string">
+			<default></default>
+		</entry>
+		<entry name="textc8bright" type="string">
+				<default></default>
+		</entry>
 		<entry name="outlineColor" type="string">
 			<default></default>
 		</entry>

--- a/package/contents/ui/config/ConfigAppearance.qml
+++ b/package/contents/ui/config/ConfigAppearance.qml
@@ -35,10 +35,115 @@ LibConfig.FormKCM {
 		text: i18n("Colors")
 	}
 	LibConfig.ColorField {
-		Kirigami.FormData.label: i18n("Text:")
+		Kirigami.FormData.label: i18n("Foreground:")
 		configKey: 'textColor'
 		defaultColor: PlasmaCore.Theme.textColor
 	}
+	//Black / Bright Black
+	RowLayout {
+		Kirigami.FormData.label: i18n("Color 1:")
+		spacing: 0
+		LibConfig.ColorField {
+			configKey: 'textc1base'
+			defaultColor: '#000000'
+		}
+		LibConfig.ColorField {
+			configKey: 'textc1bright'
+			defaultColor: '#656565'
+		}
+	}
+	// Red / Bright Red
+	RowLayout {
+		Kirigami.FormData.label: i18n("Color 2:")
+		spacing: 0
+		LibConfig.ColorField {
+			configKey: 'textc2base'
+			defaultColor: '#aa0000'
+		}
+		LibConfig.ColorField {
+			configKey: 'textc2bright'
+			defaultColor: '#ff6565'
+		}
+	}
+	// Green / Bright Green
+	RowLayout {
+		Kirigami.FormData.label: i18n("Color 3:")
+		spacing: 0
+		LibConfig.ColorField {
+			configKey: 'textc3base'
+			defaultColor: '#00aa00'
+		}
+		LibConfig.ColorField {
+			configKey: 'textc3bright'
+			defaultColor: '#65ff65'
+		}
+	}
+	// Yellow / Bright Yellow
+	RowLayout {
+		Kirigami.FormData.label: i18n("Color 4:")
+		spacing: 0
+		LibConfig.ColorField {
+			configKey: 'textc4base'
+			defaultColor: '#aa6500'
+		}
+		LibConfig.ColorField {
+			configKey: 'textc4bright'
+			defaultColor: '#ffff65'
+		}
+	}
+	//Blue / Bright Blue
+	RowLayout {
+		Kirigami.FormData.label: i18n("Color 5:")
+		spacing: 0
+		LibConfig.ColorField {
+			configKey: 'textc5base'
+			defaultColor: '#0000aa'
+		}
+		LibConfig.ColorField {
+			configKey: 'textc5bright'
+			defaultColor: '#6565ff'
+		}
+	}
+	// Magenta / Bright Magenta
+	RowLayout {
+		Kirigami.FormData.label: i18n("Color 6:")
+		spacing: 0
+		LibConfig.ColorField {
+			configKey: 'textc6base'
+			defaultColor: '#aa00aa'
+		}
+		LibConfig.ColorField {
+			configKey: 'textc6bright'
+			defaultColor: '#ff65ff'
+		}
+	}
+	// Cyan / Bright Cyan
+	RowLayout {
+		Kirigami.FormData.label: i18n("Color 7:")
+		spacing: 0
+		LibConfig.ColorField {
+			configKey: 'textc7base'
+			defaultColor: '#00aaaa'
+		}
+		LibConfig.ColorField {
+			configKey: 'textc7bright'
+			defaultColor: '#65ffff'
+		}
+	}
+	//White / Bright White
+	RowLayout {
+		Kirigami.FormData.label: i18n("Color 8:")
+		spacing: 0
+		LibConfig.ColorField {
+			configKey: 'textc8base'
+			defaultColor: '#aaaaaa'
+		}
+		LibConfig.ColorField {
+			configKey: 'textc8bright'
+			defaultColor: '#ffffff'
+		}
+	}
+
 	RowLayout {
 		Kirigami.FormData.label: i18n("Outline:")
 		spacing: 0

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -61,22 +61,22 @@ PlasmoidItem {
 		readonly property bool showOutline: plasmoid.configuration.showOutline
 
 		readonly property var ansiColors: ({
-			30: plasmoid.configuration.textc1base, // Black
-			31: plasmoid.configuration.textc2base, // Red
-			32: plasmoid.configuration.textc3base, // Green
-			33: plasmoid.configuration.textc4base, // Yellow
-			34: plasmoid.configuration.textc5base, // Blue
-			35: plasmoid.configuration.textc6base, // Magenta
-			36: plasmoid.configuration.textc7base, // Cyan
-			37: plasmoid.configuration.textc8base, // White
-			90: plasmoid.configuration.textc1bright, // Bright Black
-			91: plasmoid.configuration.textc2bright, // Bright Red
-			92: plasmoid.configuration.textc3bright, // Bright Green
-			93: plasmoid.configuration.textc4bright, // Bright Yellow
-			94: plasmoid.configuration.textc5bright, // Bright Blue
-			95: plasmoid.configuration.textc6bright, // Bright Magenta
-			96: plasmoid.configuration.textc7bright, // Bright Cyan
-			97: plasmoid.configuration.textc8bright, // Bright White
+			30: plasmoid.configuration.textc1base || '#000000', // Black
+			31: plasmoid.configuration.textc2base || '#aa0000', // Red
+			32: plasmoid.configuration.textc3base || '#00aa00', // Green
+			33: plasmoid.configuration.textc4base || '#aa6500', // Yellow
+			34: plasmoid.configuration.textc5base || '#0000aa', // Blue
+			35: plasmoid.configuration.textc6base || '#aa00aa', // Magenta
+			36: plasmoid.configuration.textc7base || '#00aaaa', // Cyan
+			37: plasmoid.configuration.textc8base || '#aaaaaa', // White
+			90: plasmoid.configuration.textc1bright || '#656565', // Bright Black
+			91: plasmoid.configuration.textc2bright || '#ff6565', // Bright Red
+			92: plasmoid.configuration.textc3bright || '#65ff65', // Bright Green
+			93: plasmoid.configuration.textc4bright || '#ffff65', // Bright Yellow
+			94: plasmoid.configuration.textc5bright || '#6565ff', // Bright Blue
+			95: plasmoid.configuration.textc6bright || '#ff65ff', // Bright Magenta
+			96: plasmoid.configuration.textc7bright || '#65ffff', // Bright Cyan
+			97: plasmoid.configuration.textc8bright || '#ffffff', // Bright White
 		})
 
 		onCommandChanged: widget.runCommand()

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -60,6 +60,25 @@ PlasmoidItem {
 		readonly property color outlineColor: plasmoid.configuration.outlineColor || Kirigami.Theme.backgroundColor
 		readonly property bool showOutline: plasmoid.configuration.showOutline
 
+		readonly property var ansiColors: ({
+			30: plasmoid.configuration.textc1base, // Black
+			31: plasmoid.configuration.textc2base, // Red
+			32: plasmoid.configuration.textc3base, // Green
+			33: plasmoid.configuration.textc4base, // Yellow
+			34: plasmoid.configuration.textc5base, // Blue
+			35: plasmoid.configuration.textc6base, // Magenta
+			36: plasmoid.configuration.textc7base, // Cyan
+			37: plasmoid.configuration.textc8base, // White
+			90: plasmoid.configuration.textc1bright, // Bright Black
+			91: plasmoid.configuration.textc2bright, // Bright Red
+			92: plasmoid.configuration.textc3bright, // Bright Green
+			93: plasmoid.configuration.textc4bright, // Bright Yellow
+			94: plasmoid.configuration.textc5bright, // Bright Blue
+			95: plasmoid.configuration.textc6bright, // Bright Magenta
+			96: plasmoid.configuration.textc7bright, // Bright Cyan
+			97: plasmoid.configuration.textc8bright, // Bright White
+		})
+
 		onCommandChanged: widget.runCommand()
 		onTooltipCommandChanged: widget.runCommand()
 		onIntervalChanged: {
@@ -77,25 +96,6 @@ PlasmoidItem {
 		}
 	}
 
-	// https://stackoverflow.com/questions/4842424/list-of-ansi-color-escape-sequences
-	property var ansiColors: ({
-		30: '#000000', // Black
-		31: '#aa0000', // Red
-		32: '#00aa00', // Green
-		33: '#aa6500', // Yellow
-		34: '#0000aa', // Blue
-		35: '#aa00aa', // Magenta
-		36: '#00aaaa', // Cyan
-		37: '#aaaaaa', // White
-		90: '#656565', // Bright Black
-		91: '#ff6565', // Bright Red
-		92: '#65ff65', // Bright Green
-		93: '#ffff65', // Bright Yellow
-		94: '#6565ff', // Bright Blue
-		95: '#ff65ff', // Bright Magenta
-		96: '#65ffff', // Bright Cyan
-		97: '#ffffff', // Bright White
-	})
 	function resetState(state) {
 		var out = state.closeTags.join(' ')
 		state.bold = false
@@ -115,7 +115,7 @@ PlasmoidItem {
 				// 30 => 90
 				n += 60
 			}
-			var hexColor = ansiColors[n]
+			var hexColor = config.ansiColors[n]
 			state.closeTags.push('</font>')
 			return '<font color="' + hexColor + '">'
 		} else {
@@ -148,10 +148,10 @@ PlasmoidItem {
 			var n = parseInt(tokens[++i], 10)
 			if (0 <= n && n <= 7) { // Normal
 				var u = n + 30
-				return ansiColors[u]
+				return config.ansiColors[u]
 			} else if (8 <= n && n <= 15) { // Bright
 				var u = n - 8 + 90
-				return ansiColors[u]
+				return config.ansiColors[u]
 			} else if (16 <= n && n <= 231) { // 212
 				var u = n - 16
 				var r = Math.floor(((u / 36) % 6) != 0 ? (40 * ((u / 36) % 6) + 55) : 0)


### PR DESCRIPTION
Adds the ability to configure the hardcoded ANSI color values, similar to Konsole. 
Example is running `neofetch`
Before:
![imagePre](https://github.com/user-attachments/assets/65109c93-bcfd-4114-ba91-0f86ed22f9f8)
After:
![imagePost](https://github.com/user-attachments/assets/3a8da3c1-c734-43b9-bba1-55dc9ee6d931)

The improper formatting is not handled in this PR. 

TODO:
- [x] Colors unchanged from their default value show up as default text.